### PR TITLE
Add RSS SSE streaming and frontend updates

### DIFF
--- a/backend/newsfeed/feed/urls.py
+++ b/backend/newsfeed/feed/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import NewsFeedView
+from .views import NewsFeedView, NewsFeedStreamView
 
 urlpatterns = [
     path('newsfeed/', NewsFeedView.as_view(), name='newsfeed'),
+    path('newsfeed/stream/', NewsFeedStreamView.as_view(), name='newsfeed-stream'),
 ]

--- a/backend/newsfeed/feed/views.py
+++ b/backend/newsfeed/feed/views.py
@@ -1,19 +1,39 @@
 import feedparser
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from django.http import StreamingHttpResponse
+import json
 
-FEED_URL = 'https://feeds.feedburner.com/ft/PEfeed'
+# RSS feed used as the data source
+FEED_URL = 'https://www.nytimes.com/svc/collections/v1/publish/http://www.nytimes.com/topic/subject/private-equity/rss.xml'
+
+
+def parse_feed():
+    """Parse the RSS feed and return a list of items."""
+    feed = feedparser.parse(FEED_URL)
+    return [
+        {
+            'title': entry.get('title'),
+            'link': entry.get('link'),
+            'published': entry.get('published'),
+            'summary': entry.get('summary'),
+        }
+        for entry in feed.entries[:10]
+    ]
 
 class NewsFeedView(APIView):
     def get(self, request):
-        feed = feedparser.parse(FEED_URL)
-        items = [
-            {
-                'title': entry.get('title'),
-                'link': entry.get('link'),
-                'published': entry.get('published'),
-                'summary': entry.get('summary'),
-            }
-            for entry in feed.entries[:10]
-        ]
-        return Response(items)
+        return Response(parse_feed())
+
+
+class NewsFeedStreamView(APIView):
+    """Stream RSS items as Server-Sent Events."""
+
+    def get(self, request):
+        items = parse_feed()
+
+        def event_stream():
+            for item in items:
+                yield f"data: {json.dumps(item)}\n\n"
+
+        return StreamingHttpResponse(event_stream(), content_type='text/event-stream')

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,24 +1,47 @@
 import { useEffect, useState } from 'react';
 
+function timeAgo(dateStr) {
+  const diff = Math.floor((Date.now() - new Date(dateStr)) / 1000);
+  if (diff < 60) return `${diff} sec ago`;
+  const m = Math.floor(diff / 60);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} hr ago`;
+  const d = Math.floor(h / 24);
+  return `${d} day${d > 1 ? 's' : ''} ago`;
+}
+
 export default function Home() {
   const [items, setItems] = useState([]);
+  const [toast, setToast] = useState('');
 
   useEffect(() => {
     fetch('http://localhost:8000/api/newsfeed/')
       .then(res => res.json())
       .then(data => setItems(data));
+
+    const es = new EventSource('http://localhost:8000/api/newsfeed/stream/');
+    es.onmessage = evt => {
+      const item = JSON.parse(evt.data);
+      setItems(prev => [item, ...prev]);
+      setToast('New item available');
+      setTimeout(() => setToast(''), 3000);
+    };
+
+    return () => es.close();
   }, []);
 
   return (
     <div>
       <h1>Newsfeed</h1>
+      {toast && <div style={{ background: '#333', color: '#fff', padding: '10px' }}>{toast}</div>}
       <ul>
         {items.map((item, idx) => (
           <li key={idx}>
             <a href={item.link} target="_blank" rel="noopener noreferrer">
               {item.title}
             </a>
-            <p>{item.published}</p>
+            <p>{timeAgo(item.published)}</p>
             <div dangerouslySetInnerHTML={{ __html: item.summary }} />
           </li>
         ))}


### PR DESCRIPTION
## Summary
- update backend feed URL to the NYT private equity feed
- factor out RSS parsing and expose it via REST
- add a new Server‑Sent Events endpoint
- display streaming items in frontend with relative timestamps and a toast

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684afb43daa4832d8b3dbf100d8fc184