### PR TITLE
Fix DRF browsable API

### DIFF
--- a/backend/newsfeed/newsfeed/settings.py
+++ b/backend/newsfeed/newsfeed/settings.py
@@ -20,7 +20,20 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'newsfeed.newsfeed.urls'
 
-TEMPLATES = []
+# Enable Django templates so the REST framework's browsable API works
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+            ],
+        },
+    },
+]
 
 WSGI_APPLICATION = 'newsfeed.newsfeed.wsgi.application'
 
@@ -32,3 +45,9 @@ DATABASES = {
 }
 
 STATIC_URL = '/static/'
+
+# Disable Django authentication to keep the project minimal
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [],
+    'UNAUTHENTICATED_USER': None,
+}


### PR DESCRIPTION
## Summary
- enable the default Django template engine
- disable authentication for DRF to avoid missing auth app

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684afc8dad38832dab1b84fbc89b8569