### PR TITLE
Fix CORS for React frontend

### DIFF
--- a/backend/newsfeed/newsfeed/settings.py
+++ b/backend/newsfeed/newsfeed/settings.py
@@ -8,6 +8,7 @@ DEBUG = True
 ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.contenttypes',
     'django.contrib.staticfiles',
     'rest_framework',
@@ -15,6 +16,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
 ]
 
@@ -51,3 +53,8 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [],
     'UNAUTHENTICATED_USER': None,
 }
+
+# Allow the local Next.js frontend to make cross-origin requests
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 django>=4.2
 djangorestframework>=3.14
 feedparser>=6.0
+django-cors-headers>=4.3


### PR DESCRIPTION
## Summary
- add `django-cors-headers` and configure CORS so the Next.js frontend can talk to Django

## Testing
- `python -m pip install -r backend/requirements.txt` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b02449570832d85ce2a4864a89549